### PR TITLE
Update normalized persistent entropy definition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "teaspoon"
-version = "1.4.6"
+version = "1.4.7"
 authors = [
   { name="Elizabeth Munch", email="muncheli@msu.edu" },
 ]

--- a/teaspoon/teaspoon/SP/information/entropy.py
+++ b/teaspoon/teaspoon/SP/information/entropy.py
@@ -97,8 +97,8 @@ def PersistentEntropy(lifetimes, normalize=False):
     if len(lt) == 0:
         E = np.nan
     Emax = 1
-    if normalize == True:
-        Emax = np.log2(sum(lt))
+    if normalize == True and len(lt) > 1:
+        Emax = np.log2(len(lt))
     PerEn = E/Emax
 
     return PerEn


### PR DESCRIPTION
Current method is inconsistent with literature. Dividing by the log of the sum of the lifetimes can make the normalized entropy negative for some point clouds. It is now computed by dividing by the log of the number of intervals.