### PR TITLE
Fix NameError in F_PSignature on Python 3.13 (#179)

### DIFF
--- a/teaspoon/teaspoon/ML/feature_functions.py
+++ b/teaspoon/teaspoon/ML/feature_functions.py
@@ -1032,10 +1032,12 @@ def F_PSignature(PL, L_Number=[]):
 
             # define first function of path
             g = Piecewise((0, t < 0), (t, t >= 0))
+            segments = []
             for j in range(0, len(x)-1):
-                function_name = 'f_%d_%d_case%d' % (j+1, 1, i+1)
-                exec(
-                    "%s = ((y[j+1]-y[j])/(x[j+1]-x[j]))*t+(y[j+1]*(x[j+1]-x[j])+x[j+1]*(y[j]-y[j+1]))/(x[j+1]-x[j])" % (function_name))
+                slope = (y[j+1]-y[j])/(x[j+1]-x[j])
+                intercept = (y[j+1]*(x[j+1]-x[j]) +
+                             x[j+1]*(y[j]-y[j+1]))/(x[j+1]-x[j])
+                segments.append(slope*t + intercept)
 
             lower_bound = x[0]
             upper_bound = x[-1]
@@ -1053,9 +1055,8 @@ def F_PSignature(PL, L_Number=[]):
             S_2_2 = 0
             for j in range(0, len(x)-1):
 
-                f_name = 'f_%d_%d_case%d' % (j+1, 1, i+1)
-                exec(
-                    'global PL_function; PL_function = Piecewise((0,t<x[j]),(0,t>x[j+1]),(%s ,True))' % (f_name))
+                PL_function = Piecewise(
+                    (0, t < x[j]), (0, t > x[j+1]), (segments[j], True))
                 # S(2)
                 Signature_2 = integrate(diff(PL_function), (t, x[j], x[j+1]))
                 S_2 = S_2 + float(Signature_2)


### PR DESCRIPTION
## Description
The `F_PSignature` function used `exec()` to create dynamically-named local variables and read them in a second `exec()` call. This worked on older Python because both `exec()` calls shared the same locals dict, but Python 3.13 changed `locals()` to return a fresh snapshot each call (PEP 667), so the second `exec` couldn't see what the first one defined. 

The fix replaces the two `exec()` calls with a regular Python list of sympy expressions indexed by segment. No string templating, no scope tricks, and the math is unchanged.

## Motivation and Context
Fixes #179. The path signature classification example from the docs (https://teaspoontda.github.io/teaspoon/modules/ML/CL_PS.html) crashes on Python 3.13 with `NameError: name 'f_1_1_case1' is not defined`, which makes the documented workflow unusable on the latest Python.

## How has this been tested?
  - Reproduced the original `NameError` on Python 3.13.13 using the upstream `teaspoon` 1.5.30 from pip.
  - Confirmed the patched version runs the documented `CL_PS` example end-to-end on Python 3.13.13.
  - Compared output against the original on Python 3.10 across 24 diagrams with `L=[1]` and 23 diagrams with `L=[1,2]`: max absolute difference is `0.0` (bitwise identical).
  - Verified algebraic equivalence of the rewritten linear-segment formula with `sympy.simplify` (difference is `0`).
  - Existing unit tests still pass: `tests/test_classification.py` and `tests/test_featureFunctions.py` (4 passed).

  ## Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

  ## Checklist
  - [x] My code follows the code style of this project. (`make clean`)
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly. (`make html`)
  - [ ] I have incremented the version number in the `pyproject.toml` file.
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed. (`make tests`)