### PR TITLE
Add return_models option to getPercentScore (#181)

### DIFF
--- a/doc_source/modules/ML/CL_CC.rst
+++ b/doc_source/modules/ML/CL_CC.rst
@@ -251,8 +251,60 @@ Algorithm implements `GridSearchCV
     Average accuracy: 0.842
     Standard deviation: 0.010
 
-    For more metrics, see the outputs.    
+    For more metrics, see the outputs.
 
+Extracting the trained models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+By default, ``getPercentScore`` returns only the train and test classification reports.
+If the cross-validation results look good and the user wants to apply the trained
+classifier to new data, the ``return_models=True`` option returns a third value:
+a list with one entry per cross-validation fold, each holding the fitted classifier
+and the feature scaler used during training.
 
+::
 
+    >>> from teaspoon.ML.PD_Classification import getPercentScore
+    >>> from teaspoon.ML import feature_functions as fF
+    >>> from teaspoon.ML.Base import ParameterBucket
+    >>> from teaspoon.MakeData.PointCloud import testSetManifolds
+    >>> from sklearn.preprocessing import LabelEncoder
+    >>> from sklearn.svm import SVC
 
+    >>> # generate persistence diagrams
+    >>> DgmsDF = testSetManifolds(numDgms=20, numPts=100)
+    >>> labels_col='trainingLabel'
+    >>> dgm_col='Dgm1'
+
+    >>> # convert categorical labels into integers
+    >>> label_encoder = LabelEncoder()
+    >>> y = label_encoder.fit_transform(DgmsDF[labels_col])
+    >>> DgmsDF[labels_col] = y
+
+    >>> # set classification parameters
+    >>> params = ParameterBucket()
+    >>> params.feature_function = fF.F_CCoordinates
+    >>> params.k_fold_cv = 5
+    >>> params.FN = 5
+    >>> params.clf_model = SVC
+
+    >>> # ask for the trained models in addition to the reports
+    >>> c_report_train, c_report_test, models = getPercentScore(DgmsDF,
+    >>>                                                         labels_col='trainingLabel',
+    >>>                                                         dgm_col='Dgm1',
+    >>>                                                         params=params,
+    >>>                                                         precomputed=False,
+    >>>                                                         saving=False,
+    >>>                                                         saving_path=None,
+    >>>                                                         return_models=True)
+
+    >>> # use the model from the first fold on new feature vectors
+    >>> trained = models[0]
+    >>> clf = trained['model']
+    >>> scaler = trained['scaler']
+    >>> new_features = ...  # shape (n_samples, params.FN)
+    >>> if scaler is not None:
+    >>>     new_features = scaler.transform(new_features)
+    >>> predictions = clf.predict(new_features)
+
+The ``scaler`` entry is ``None`` when the kernel method is used, since that path
+operates on a precomputed kernel matrix and does not standardize features.

--- a/teaspoon/teaspoon/ML/PD_Classification.py
+++ b/teaspoon/teaspoon/ML/PD_Classification.py
@@ -210,6 +210,7 @@ def getPercentScore(DgmsDF,
                     precomputed=False,
                     saving=False,
                     saving_path=None,
+                    return_models=False,
                     **kwargs):
     """
 
@@ -226,16 +227,18 @@ def getPercentScore(DgmsDF,
     params : parameterbucket object
         Parameter bucket object. The default is Base.ParameterBucket().
     precomputed : boolean, optional
-        If user already computed the persitence landscapes, this should be set to True, otherwise algorithm will 
+        If user already computed the persitence landscapes, this should be set to True, otherwise algorithm will
         spend time on computing these. This option is only valid when persistence landscapes are used as featurization
         methods. If this parameter is True, algorithm treat 'DgmsDF' as persistence landscapes. The default is False.
     saving : boolean, optional
         If user wants to save classification results, this should be set to True and saving_path needs to be provided. The default is False.
     saving_path : str, optional
         The path where user wants to save the results. This should be provided when saving is True. The default is None.
-    **kwargs : 
+    return_models : boolean, optional
+        If True, the trained classifier and feature scaler from each cross-validation fold are returned alongside the classification reports. The default is False.
+    **kwargs :
         Additional parameters. When user wants to apply transfer learning, the second set of persistence diagrams and their labels should be passed in a
-        dataframe format. 
+        dataframe format.
 
     Returns
     -------
@@ -243,6 +246,8 @@ def getPercentScore(DgmsDF,
         Classification report for training set results.
     c_report_test : dict
         Classification report for test set results.
+    models : list of dict, optional
+        Only returned when return_models is True. A list with one entry per cross-validation fold, each containing the keys 'model' (the fitted classifier) and 'scaler' (the fitted StandardScaler, or None for the kernel method which does not use one).
 
     """
 
@@ -261,6 +266,7 @@ def getPercentScore(DgmsDF,
     accuracy_test = []
     c_report_train = []
     c_report_test = []
+    models = []
 
     # obtain training and test sets for diagrams using the stratified k-fold
     if params.TF_Learning:
@@ -563,6 +569,7 @@ def getPercentScore(DgmsDF,
                 accuracy_train.append(cr_train['accuracy'])
                 c_report_train.append(cr_train)
                 c_report_test.append(cr_test)
+                models.append({'model': clf, 'scaler': None})
 
                 print('Run Number: {}'.format(k_fold+1))
                 print('Test set acc.: {:.3f} \nTraining set acc.: {:.3f}'.format(
@@ -619,6 +626,7 @@ def getPercentScore(DgmsDF,
             accuracy_train.append(cr_train['accuracy'])
             c_report_train.append(cr_train)
             c_report_test.append(cr_test)
+            models.append({'model': model, 'scaler': scaler})
 
             print('Run Number: {}'.format(k_fold+1))
             print('Test set acc.: {:.3f} \nTraining set acc.: {:.3f}'.format(
@@ -651,4 +659,6 @@ def getPercentScore(DgmsDF,
         pickle.dump(c_report_train, f)
         f.close()
 
+    if return_models:
+        return c_report_train, c_report_test, models
     return c_report_train, c_report_test


### PR DESCRIPTION
## Description
Adds an optional `return_models=False` keyword to `getPercentScore`. When set to True, the function returns a third value: a list of `{model, scaler}` dicts, one per cross-validation fold. Each entry holds the fitted classifier and the StandardScaler that was applied to its training features, so users can run the model on new raw data with `scaler.transform(...)` followed by `model.predict(...)`. The kernel-method branch sets `scaler` to `None` since that path doesn't use one. Default behavior is unchanged,  old callers continue to receive the 2-tuple `(c_report_train, c_report_test)`.

## Motivation and Context
Closes #181. As @Ignaci09 pointed out, `getPercentScore` only returned the train and test reports, so there was no way to use the trained models for prediction after cross-validation. With `return_models=True`, the fitted estimator and its corresponding scaler are now accessible.

## How has this been tested?
  - Confirmed the default 2-tuple return is unchanged for existing callers.
  - Confirmed `return_models=True` returns a 3-tuple, with `len(models) == params.k_fold_cv`.
  - Used a returned `(model, scaler)` pair to run `predict()` on unseen samples — output matches expectations.
  - Verified the kernel-method branch returns `scaler=None` (since it doesn't apply a StandardScaler) while still returning the fitted `SVC(kernel='precomputed')`.
  - Existing test suite (`tests/test_classification.py`, `tests/test_featureFunctions.py`) — 4 passed.
  - Confirmed both APIs work on Python 3.13.13 as well as 3.10.
  - Rebuilt the docs locally with `make html` to confirm the new "Extracting the trained models" section renders cleanly with no new Sphinx warnings

  ## Types of changes
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
  - [x] My code follows the code style of this project. (`make clean`)
  - [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly. (`make html`)
  - [ ] I have incremented the version number in the `pyproject.toml` file.
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed. (`make tests`)