### PR TITLE
Fix unguarded gudhi.tensorflow import crashing data_assimilation on plain install (#197)

### DIFF
--- a/teaspoon/teaspoon/DAF/data_assimilation.py
+++ b/teaspoon/teaspoon/DAF/data_assimilation.py
@@ -1,6 +1,5 @@
 import numpy as np
 import gudhi as gd
-from gudhi.tensorflow import RipsLayer
 from gudhi.wasserstein import wasserstein_distance
 from teaspoon.DAF.forecasting import get_forecast
 from teaspoon.DAF.forecasting import forecast_time
@@ -9,8 +8,10 @@ from teaspoon.DAF.forecasting import random_feature_map_model
 try:
     import tensorflow as tf
     from tensorflow import keras
-except:
-    raise ImportError("TADA Requires tensorflow for optimization")
+    from gudhi.tensorflow import RipsLayer
+    _tensorflow_available = True
+except ImportError:
+    _tensorflow_available = False
 
 
 def TADA(u_obs, window_size, model_parameters, n_epochs=1, train_len=4000, opt_params=[1e-5, 0.99], window_number=1, j2_sample_size=50):
@@ -30,6 +31,10 @@ def TADA(u_obs, window_size, model_parameters, n_epochs=1, train_len=4000, opt_p
         Returns:
             (array): Updated model weights using TADA algorithm.
     '''
+
+    if not _tensorflow_available:
+        raise ImportError(
+            "TADA requires TensorFlow. Install with: pip install 'teaspoon[full]'")
 
     # Grow the window size as new measurements are received
     if window_number < window_size:


### PR DESCRIPTION
## Description
`data_assimilation.py` had `from gudhi.tensorflow import RipsLayer` at the top of the file (line 3), outside any try/except block. Since `gudhi.tensorflow` internally imports TensorFlow, this caused the entire module to crash on import when TensorFlow was not installed,  even though TensorFlow is an optional dependency only needed by `TADA`.The fix moves the import inside the existing try/except block and replaces the bare `except` with `except ImportError`. Instead of raising immediately at module load time, a flag `_tensorflow_available` is set and checked at the start of `TADA`. This means:
  - `rafda` can be imported and used on a plain `pip install teaspoon` with no TensorFlow
  - Calling `TADA` without TensorFlow raises a clear `ImportError` pointing the user to `pip install 'teaspoon[full]'`

## Motivation and Context
  Closes #197. " teaspoon.DAF.data_assimilation crashes on import after plain "pip install teaspoon" => unguarded from gudhi.tensorflow import RipsLayer on line 3 defeats the developer's own tensorflow try/except #197 "

## How has this been tested?
  - Confirmed `from teaspoon.DAF.data_assimilation import rafda` succeeds without TensorFlow installed.
  - Confirmed `from teaspoon.DAF.data_assimilation import TADA` succeeds without TensorFlow installed.
  - Confirmed calling `TADA(...)` without TensorFlow raises `ImportError` with the message `"TADA requires TensorFlow. Install with: pip install 'teaspoon[full]'"`.
  - Verified via AST check that `RipsLayer` is no longer imported at the module top level.
  - Existing DAF test suite (`tests/test_DAF.py`) — 1 skipped (expected: the test correctly skips itself when TensorFlow is not available).

## Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
  - [x] My code follows the code style of this project. (`make clean`)
  - [ ] My change requires a change to the documentation.
  - [x] All new and existing tests passed. (`make tests`)