### PR TITLE
Fix DistanceMatrix crash on read-only array from remove_zerors #199

### DIFF
--- a/teaspoon/teaspoon/TDA/PHN.py
+++ b/teaspoon/teaspoon/TDA/PHN.py
@@ -32,7 +32,7 @@ def DistanceMatrix(A, method='shortest_unweighted_path'):
         print('Defaulting to unweighted shortest path.')
         method = 'shortest_unweighted_path'
 
-    A = network_tools.remove_zeros(A)
+    A = np.array(network_tools.remove_zeros(A))
     np.fill_diagonal(A, 0)
     A = A + A.T
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`  DistanceMatrix` in `teaspoon/TDA/PHN.py` called `np.fill_diagonal(A, 0)` on the array returned by `network_tools.remove_zeros`. That function returns its result via pandas `to_numpy()`, which is read-only on the numpy/pandas versions resolved for Python 3.11 and 3.12. Since `np.fill_diagonal` writes in place, it raised `ValueError: underlying array is read-only`, which failed the CI test suite on 3.11 and 3.12 while 3.9 and 3.10 passed.

The fix wraps the result in `np.array(...)`, which returns a writable copy regardless of the input's read-only flag. The diagonal is still zeroed exactly as before.

## Motivation and Context
Closes #199. The `Test Installs` workflow was red on Python 3.11 and 3.12 (all platforms), which blocked the checks on every pull request. This was pre-existing and not introduced by any recent.

## How has this been tested?
- Reproduced the exact failure by forcing `remove_zeros` to return a read-only array, then confirmed `DistanceMatrix` raised `underlying array is read-only` without the fix.
- With the fix, ran both affected tests (`test_point_summaries_empty_persistence_diagram`, test_point_summaries_non_empty_persistence_diagram`) end-to-end under the same read-only condition — both pass, and no further read-only error appears downstream.
- Ran `tests/test_PointSummariesPHN.py` normally — 2 passed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the code style of this project. (`make clean`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (`make html`)
- [ ] I have incremented the version number in the `pyproject.toml` file.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. (`make tests`)