### PR TITLE
Speed up permutation_sequence, 1-D maps, and MsPE without changing results

### DIFF
--- a/teaspoon/teaspoon/MakeData/DynSysLib/maps.py
+++ b/teaspoon/teaspoon/MakeData/DynSysLib/maps.py
@@ -50,11 +50,12 @@ def logistic_map(parameters=[3.5], dynamic_state=None, InitialConditions=None,
         InitialConditions = [0.5]
     xn = InitialConditions[0]
 
-    t, ts = [], []
-    for n in range(0, int(L)):
+    N = int(L)
+    ts = np.empty(N)
+    for n in range(0, N):
         xn = r*xn*(1-xn)
-        ts = np.append(ts, xn)
-        t = np.append(t, n)
+        ts[n] = xn
+    t = np.arange(N, dtype=float)
 
     ts = [ts[-SampleSize:]]
     t = t[-SampleSize:]
@@ -177,11 +178,12 @@ def sine_map(parameters=[0.8], dynamic_state=None, InitialConditions=None,
         InitialConditions = [0.1]
     xn = InitialConditions[0]
 
-    t, ts = [], []
-    for n in range(0, int(L)):
+    N = int(L)
+    ts = np.empty(N)
+    for n in range(0, N):
         xn = A*np.sin(np.pi*xn)
-        ts = np.append(ts, xn)
-        t = np.append(t, n)
+        ts[n] = xn
+    t = np.arange(N, dtype=float)
 
     ts = [ts[-SampleSize:]]
     t = t[-SampleSize:]
@@ -237,11 +239,12 @@ def tent_map(parameters=[1.05], dynamic_state=None, InitialConditions=None,
         InitialConditions = [1/np.sqrt(2)]
     xn = InitialConditions[0]
 
-    t, ts = [], []
-    for n in range(0, int(L)):
+    N = int(L)
+    ts = np.empty(N)
+    for n in range(0, N):
         xn = A*np.min([xn, 1-xn])
-        ts = np.append(ts, xn)
-        t = np.append(t, n)
+        ts[n] = xn
+    t = np.arange(N, dtype=float)
 
     ts = [ts[-SampleSize:]]
     t = t[-SampleSize:]
@@ -292,11 +295,12 @@ def linear_congruential_generator_map(parameters=[0.9, 54773, 259200], dynamic_s
         InitialConditions = [0.1]
     xn = InitialConditions[0]
 
-    t, ts = [], []
-    for n in range(0, int(L)):
+    N = int(L)
+    ts = np.empty(N)
+    for n in range(0, N):
         xn = (a*xn + b) % c
-        ts = np.append(ts, xn)
-        t = np.append(t, n)
+        ts[n] = xn
+    t = np.arange(N, dtype=float)
 
     ts = [ts[-SampleSize:]]
     t = t[-SampleSize:]
@@ -353,11 +357,12 @@ def rickers_population_map(parameters=[13], dynamic_state=None, InitialCondition
         InitialConditions = [0.1]
     xn = InitialConditions[0]
 
-    t, ts = [], []
-    for n in range(0, int(L)):
+    N = int(L)
+    ts = np.empty(N)
+    for n in range(0, N):
         xn = a*xn*np.exp(-xn)
-        ts = np.append(ts, xn)
-        t = np.append(t, n)
+        ts[n] = xn
+    t = np.arange(N, dtype=float)
 
     ts = [ts[-SampleSize:]]
     t = t[-SampleSize:]
@@ -415,11 +420,12 @@ def gauss_map(parameters=[6.20, -0.20], dynamic_state=None, InitialConditions=No
         InitialConditions = [0.1]
     xn = InitialConditions[0]
 
-    t, ts = [], []
-    for n in range(0, int(L)):
+    N = int(L)
+    ts = np.empty(N)
+    for n in range(0, N):
         xn = np.exp(-alpha*xn**2) + beta
-        ts = np.append(ts, xn)
-        t = np.append(t, n)
+        ts[n] = xn
+    t = np.arange(N, dtype=float)
 
     ts = [ts[-SampleSize:]]
     t = t[-SampleSize:]
@@ -476,11 +482,12 @@ def cusp_map(parameters=[1.1], dynamic_state=None, InitialConditions=None,
         InitialConditions = [0.5]
     xn = InitialConditions[0]
 
-    t, ts = [], []
-    for n in range(0, int(L)):
+    N = int(L)
+    ts = np.empty(N)
+    for n in range(0, N):
         xn = 1-a*np.sqrt(np.abs(xn))
-        ts = np.append(ts, xn)
-        t = np.append(t, n)
+        ts[n] = xn
+    t = np.arange(N, dtype=float)
 
     ts = [ts[-SampleSize:]]
     t = t[-SampleSize:]
@@ -537,11 +544,12 @@ def pinchers_map(parameters=[1.3, 0.5], dynamic_state=None, InitialConditions=No
         InitialConditions = [0.0]
     xn = InitialConditions[0]
 
-    t, ts = [], []
-    for n in range(0, int(L)):
+    N = int(L)
+    ts = np.empty(N)
+    for n in range(0, N):
         xn = np.abs(np.tanh(s*(xn-c)))
-        ts = np.append(ts, xn)
-        t = np.append(t, n)
+        ts[n] = xn
+    t = np.arange(N, dtype=float)
 
     ts = [ts[-SampleSize:]]
     t = t[-SampleSize:]
@@ -598,11 +606,12 @@ def sine_circle_map(parameters=[0.5, 1.5], dynamic_state=None, InitialConditions
         InitialConditions = [0.0]
     xn = InitialConditions[0]
 
-    t, ts = [], []
-    for n in range(0, int(L)):
+    N = int(L)
+    ts = np.empty(N)
+    for n in range(0, N):
         xn = xn + omega - (k/(2*np.pi))*np.sin(2*np.pi*xn) % 1
-        ts = np.append(ts, xn)
-        t = np.append(t, n)
+        ts[n] = xn
+    t = np.arange(N, dtype=float)
 
     ts = [ts[-SampleSize:]]
     t = t[-SampleSize:]

--- a/teaspoon/teaspoon/SP/tsa_tools.py
+++ b/teaspoon/teaspoon/SP/tsa_tools.py
@@ -146,21 +146,22 @@ def permutation_sequence(ts, n=None, tau=None):
         deg = len(perm)
         return sum([perm[k]*deg**k for k in range(deg)])
     L = len(time_series)  # total length of time series
-    perm_order = []  # prepares permutation sequence array
     # prepares all possible permutations for comparison
     permutations = np.array(list(itertools.permutations(range(m))))
     hashlist = [util_hash_term(perm)
                 for perm in permutations]  # prepares hashlist
-    for i in range(L - delay * (m - 1)):
-        # For all possible permutations in time series
-        sorted_index_array = np.array(np.argsort(
-            time_series[i:i + delay * m:delay], kind='quicksort'))
-        # sort array for catagorization
-        hashvalue = util_hash_term(sorted_index_array)
-        # permutation type
-        perm_order = np.append(
-            perm_order, np.argwhere(hashlist == hashvalue)[0][0])
-        # appends new permutation to end of array
+    hl = np.asarray(hashlist)
+    order = np.argsort(hl)
+    ts_arr = np.asarray(time_series)
+    nw = L - delay * (m - 1)
+    if nw > 0:
+        win_idx = np.arange(nw)[:, None] + delay * np.arange(m)[None, :]
+        ranks = np.argsort(ts_arr[win_idx], axis=1, kind='quicksort')
+        hashvalues = ranks.dot(m ** np.arange(m))
+        perm_order = order[np.searchsorted(hl[order], hashvalues)]
+    else:
+        # no windows: leave a list so .astype below raises as the original did
+        perm_order = []
     # sets permutation type as integer where $p_i \in \mathbb{z}_{>0}$
     perm_seq = perm_order.astype(int)+1
     return perm_seq  # returns sequence of permutations

--- a/teaspoon/teaspoon/parameter_selection/MsPE.py
+++ b/teaspoon/teaspoon/parameter_selection/MsPE.py
@@ -44,7 +44,7 @@ def MsPE_tau(time_series, delay_end=200, plotting=False):
                 delay_peak = delay-1
                 end = True
             NPE_previous = NPE
-        MSPE = np.append(MSPE, NPE)
+        MSPE.append(NPE)
         delays.append(delay)
 
         if delay > de:
@@ -91,7 +91,7 @@ def MsPE_n(time_series, delay, m_start=3, m_end=7, plotting=False):
     for m in range(m_start, m_end+1):
         PE = ent.permutation_entropy(time_series, m, delay)/(np.log(2))
         NPE = PE/(m-1)
-        MnPE = np.append(MnPE, NPE)
+        MnPE.append(NPE)
     dim = np.argmax(MnPE)
 
     if plotting == True:


### PR DESCRIPTION
## Description
A few functions were using np.append inside loops, which recopies the whole array every iteration and gets slow on bigger inputs. I swapped those out for preallocated arrays, and vectorized the per-window loop in permutation_sequence. Nothing about the behavior changes, just the speed.

## Motivation and Context
These were pure Python hotspots that scaled badly. permutation_sequence is now roughly 70 to 280x faster depending on signal length, and since ordinal_partition_graph calls it, that speeds up too. The 1-D maps are about 7 to 45x faster. No API or output changes, so nothing downstream needs to adapt. No open issue linked, happy to file one if you want.

## How has this been tested?
I checked the outputs are exactly the same as before, byte for byte, across 141 cases covering chaotic, periodic, random, constant, and tie-heavy signals plus a bunch of dimension and delay combos and some edge cases. All 141 match. I also ran the existing test suite. 41 of 42 pass. The one failure is test_tada, which is a pre-existing numpy/TensorFlow import issue that also fails on a clean master and has nothing to do with the files here.

## Types of changes
This is a performance change and does not break anything, so none of the boxes below fit exactly.
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
  - [x] My code follows the code style of this project. (`make clean`)
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly. (`make html`)
  - [ ] I have incremented the version number in the `pyproject.toml` file.
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed. (`make tests`)