### PR TITLE
  CI: test the PR branch on pull_request instead of hardcoded test_release

### DIFF
--- a/.github/workflows/test_installs.yml
+++ b/.github/workflows/test_installs.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@master
-        with:
-          ref: 'test_release'
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -42,8 +40,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@master
-        with:
-          ref: 'test_release'
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -64,8 +60,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@master
-        with:
-          ref: 'test_release'
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -86,8 +80,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@master
-        with:
-          ref: 'test_release'
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -108,8 +100,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@master
-        with:
-          ref: 'test_release'
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -130,8 +120,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@master
-        with:
-          ref: 'test_release'
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -152,8 +140,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@master
-        with:
-          ref: 'test_release'
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -174,8 +160,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@master
-        with:
-          ref: 'test_release'
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -196,8 +180,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@master
-        with:
-          ref: 'test_release'
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -218,8 +200,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@master
-        with:
-          ref: 'test_release'
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -240,8 +220,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@master
-        with:
-          ref: 'test_release'
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -262,8 +240,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@master
-        with:
-          ref: 'test_release'
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Description
Every job in test_installs.yml was checking out the test_release branch with `ref: 'test_release'`, no matter what triggered the workflow. That means pull requests were never testing their own code, they were testing whatever happened to be on test_release. This removes that hardcoded ref so checkout uses its normal default: pushes to test_release still test test_release, and pull requests test the PR.

## Motivation and Context
Because of the hardcoded ref, PRs to master were showing failing checks that had nothing to do with the PR. For example, a PR can go red because test_release is missing a fix that already exists on master. That makes the checks misleading and hard to trust. Letting checkout follow the event fixes this for every future PR.

## How has this been tested?
I confirmed only the workflow file changed, that all of the hardcoded test_release refs are gone, and that the push and pull_request triggers are untouched. One thing to note: GitHub runs the base branch's workflow definition for pull_request events, so the new behavior only takes full effect once this is merged into master. The checks on this PR itself may still run the old definition.

## Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
  - [ ] My code follows the code style of this project. (`make clean`)
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly. (`make html`)
  - [ ] I have incremented the version number in the `pyproject.toml` file.
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed. (`make tests`)